### PR TITLE
fix wasm middleware plugin memory leak issue

### DIFF
--- a/handler/middleware_test.go
+++ b/handler/middleware_test.go
@@ -64,7 +64,6 @@ func TestAlreadyExistingWasipModulue(t *testing.T) {
 		}
 		return r, nil
 	}))
-
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/handler/nethttp/middleware.go
+++ b/handler/nethttp/middleware.go
@@ -3,12 +3,11 @@ package wasm
 import (
 	"context"
 	"fmt"
+	handlerapi "github.com/http-wasm/http-wasm-host-go/api/handler"
+	"github.com/http-wasm/http-wasm-host-go/handler"
 	"io"
 	"net/http"
 	"runtime"
-
-	handlerapi "github.com/http-wasm/http-wasm-host-go/api/handler"
-	"github.com/http-wasm/http-wasm-host-go/handler"
 )
 
 // compile-time checks to ensure interfaces are implemented.
@@ -26,13 +25,7 @@ func NewMiddleware(ctx context.Context, guest []byte, options ...handler.Option)
 		return nil, err
 	}
 
-	mw := &middleware{m: m}
-	runtime.SetFinalizer(mw, func(mw *middleware) {
-		if err := mw.Close(ctx); err != nil {
-			fmt.Printf("[http-wasm-host-go] middleware Close failed: %v", err)
-		}
-	})
-	return mw, nil
+	return &middleware{m: m}, nil
 }
 
 // requestStateKey is a context.Context value associated with a requestState
@@ -95,12 +88,18 @@ func requestStateFromContext(ctx context.Context) *requestState {
 
 // NewHandler implements the same method as documented on handler.Middleware.
 func (w *middleware) NewHandler(_ context.Context, next http.Handler) http.Handler {
-	return &guest{
+	h := &guest{
 		handleRequest:  w.m.HandleRequest,
 		handleResponse: w.m.HandleResponse,
 		next:           next,
 		features:       w.m.Features(),
 	}
+	runtime.SetFinalizer(h, func(h *guest) {
+		if err := w.Close(context.Background()); err != nil {
+			fmt.Printf("[http-wasm-host-go] middleware Close failed: %v", err)
+		}
+	})
+	return h
 }
 
 // Close implements the same method as documented on handler.Middleware.

--- a/handler/nethttp/middleware.go
+++ b/handler/nethttp/middleware.go
@@ -3,12 +3,10 @@ package wasm
 import (
 	"context"
 	"fmt"
-	"io"
-	"net/http"
-	"runtime"
-
 	handlerapi "github.com/http-wasm/http-wasm-host-go/api/handler"
 	"github.com/http-wasm/http-wasm-host-go/handler"
+	"io"
+	"net/http"
 )
 
 // compile-time checks to ensure interfaces are implemented.
@@ -89,18 +87,12 @@ func requestStateFromContext(ctx context.Context) *requestState {
 
 // NewHandler implements the same method as documented on handler.Middleware.
 func (w *middleware) NewHandler(_ context.Context, next http.Handler) http.Handler {
-	h := &guest{
+	return &guest{
 		handleRequest:  w.m.HandleRequest,
 		handleResponse: w.m.HandleResponse,
 		next:           next,
 		features:       w.m.Features(),
 	}
-	runtime.SetFinalizer(h, func(h *guest) {
-		if err := w.Close(context.Background()); err != nil {
-			fmt.Printf("[http-wasm-host-go] middleware Close failed: %v", err)
-		}
-	})
-	return h
 }
 
 // Close implements the same method as documented on handler.Middleware.

--- a/handler/nethttp/middleware.go
+++ b/handler/nethttp/middleware.go
@@ -3,10 +3,11 @@ package wasm
 import (
 	"context"
 	"fmt"
-	handlerapi "github.com/http-wasm/http-wasm-host-go/api/handler"
-	"github.com/http-wasm/http-wasm-host-go/handler"
 	"io"
 	"net/http"
+
+	handlerapi "github.com/http-wasm/http-wasm-host-go/api/handler"
+	"github.com/http-wasm/http-wasm-host-go/handler"
 )
 
 // compile-time checks to ensure interfaces are implemented.

--- a/handler/nethttp/middleware.go
+++ b/handler/nethttp/middleware.go
@@ -3,11 +3,12 @@ package wasm
 import (
 	"context"
 	"fmt"
-	handlerapi "github.com/http-wasm/http-wasm-host-go/api/handler"
-	"github.com/http-wasm/http-wasm-host-go/handler"
 	"io"
 	"net/http"
 	"runtime"
+
+	handlerapi "github.com/http-wasm/http-wasm-host-go/api/handler"
+	"github.com/http-wasm/http-wasm-host-go/handler"
 )
 
 // compile-time checks to ensure interfaces are implemented.


### PR DESCRIPTION



###  fixup guest module instance creation without guest module free caused memory leak

to fix https://github.com/traefik/traefik/issues/11119

upstream sync the same PR: https://github.com/http-wasm/http-wasm-host-go/pull/86


cc @juliens 

-------------------------------------------------------------

since this implementation make usage of `sync.Pool`

we must call `Close()` method of the module when the sync.Pool object got GC ed.

without call `Close()` to releases resources allocated for this Module, the memory will leak

-------------------------------------------------------------


###  related PR

see also https://github.com/traefik/traefik/pull/11151 which fixup the wasm plugin memory leak when dynamic config loading ( which cause all related route middleware recreation), we have to call `nethttp.middleware.Close()` (which will call `handler.middleware.Close()` -> `wazero.Runtime.Close()` ) to free the memory





